### PR TITLE
itty-routerを使ってルーティングを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "cloudflare-worker-api-proxy",
       "version": "0.0.0",
+      "dependencies": {
+        "itty-router": "^2.6.1"
+      },
       "devDependencies": {
         "@cloudflare/workers-types": "^3.11.0",
         "typescript": "^4.6.4",
@@ -733,6 +736,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/itty-router": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-2.6.1.tgz",
+      "integrity": "sha512-l9gxWe5TOLUESYnBn85Jxd6tIZLWdRX5YKkHIBfSgbNQ7UFPNUGuWihRV+LlEbfJJIzgLmhwAbaWRi5yWJm8kg=="
     },
     "node_modules/kleur": {
       "version": "4.1.4",
@@ -1482,6 +1490,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
+    },
+    "itty-router": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-2.6.1.tgz",
+      "integrity": "sha512-l9gxWe5TOLUESYnBn85Jxd6tIZLWdRX5YKkHIBfSgbNQ7UFPNUGuWihRV+LlEbfJJIzgLmhwAbaWRi5yWJm8kg=="
     },
     "kleur": {
       "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "scripts": {
     "start": "wrangler dev",
     "publish": "wrangler publish"
+  },
+  "dependencies": {
+    "itty-router": "^2.6.1"
   }
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,4 +1,4 @@
-export const handleRequest = async (request: Request): Promise<Response> => {
+export const handleCatImageValidation = async (request: Request): Promise<Response> => {
 
   const responseBody = { message: `Hello World!`, requestMethod: request.method };
 
@@ -7,4 +7,15 @@ export const handleRequest = async (request: Request): Promise<Response> => {
   const headers = { 'Content-Type': 'application/json' };
 
   return new Response(jsonBody, { headers });
+};
+
+export const handleNotFound = async (request: Request): Promise<Response> => {
+
+  const responseBody = { message: `NotFound`, requestMethod: request.method };
+
+  const jsonBody = JSON.stringify(responseBody, null, 2);
+
+  const headers = { 'Content-Type': 'application/json' };
+
+  return new Response(jsonBody, { headers, status: 404 });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,8 @@
  *
  * Learn more at https://developers.cloudflare.com/workers/
  */
-import { handleRequest } from './handler'
+import { router } from './router';
 
-addEventListener('fetch', (event) => {
-  event.respondWith(handleRequest(event.request))
-})
+addEventListener('fetch', (e) => {
+  e.respondWith(router.handle(e.request))
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,7 @@
+import { Router } from 'itty-router';
+import {handleCatImageValidation, handleNotFound} from "./handler";
+
+export const router = Router();
+
+router.post('/cat-images/validation-results', handleCatImageValidation);
+router.all('*', handleNotFound);


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/cloudflare-worker-api-proxy/issues/2

# やった事

公式で紹介されている `itty-router` を使ってルーティングを追加。

目的がLGTMeowのAPI Proxyの役割を果たす事なので、指定されたAPI以外は404を返すように設定。

中身の実装に関しては別PRで実装を行っていく。