### PR TITLE
Cognitoのアクセストークンを発行する機能を追加

### DIFF
--- a/src/api/issueAccessToken.ts
+++ b/src/api/issueAccessToken.ts
@@ -1,0 +1,37 @@
+type IssueAccessTokenRequest = {
+  endpoint: string;
+  cognitoClientId: string;
+  cognitoClientSecret: string;
+};
+
+type CognitoTokenResponseBody = {
+  access_token: string;
+  // eslint-disable-next-line no-magic-numbers
+  expires_in: 3600;
+  token_type: 'Bearer';
+};
+
+type JwtAccessToken = string;
+
+export const issueAccessToken = async (
+  request: IssueAccessTokenRequest,
+): Promise<JwtAccessToken> => {
+  const authorization = btoa(
+    `${request.cognitoClientId}:${request.cognitoClientSecret}`,
+  );
+
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${authorization}`,
+    },
+    body: 'grant_type=client_credentials&scope=api.lgtmeow/all image-recognition-api.lgtmeow/all',
+  };
+
+  const response = await fetch(request.endpoint, options);
+
+  const responseBody = (await response.json()) as CognitoTokenResponseBody;
+
+  return responseBody.access_token;
+};

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,5 @@
+/* eslint-disable init-declarations */
+
+declare const COGNITO_CLIENT_ID: string;
+declare const COGNITO_CLIENT_SECRET: string;
+declare const COGNITO_TOKEN_ENDPOINT: string;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,11 +1,22 @@
 /* eslint-disable require-await */
 
+import { issueAccessToken } from './api/issueAccessToken';
+
 export const handleCatImageValidation = async (
   request: Request,
 ): Promise<Response> => {
+  const issueTokenRequest = {
+    endpoint: COGNITO_TOKEN_ENDPOINT,
+    cognitoClientId: COGNITO_CLIENT_ID,
+    cognitoClientSecret: COGNITO_CLIENT_SECRET,
+  };
+
+  const jwtAccessToken = await issueAccessToken(issueTokenRequest);
+
   const responseBody = {
     message: `Hello World!`,
     requestMethod: request.method,
+    jwtAccessTokenLength: jwtAccessToken.length,
   };
 
   const jsonBody = JSON.stringify(responseBody);


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/cloudflare-worker-api-proxy/issues/2

# やった事

CognitoのAccessTokenを発行する機能を追加。

これは一時的なコードで次はこのトークンを使ってねこ画像判定APIにRequestを送信するようにします。
