### PR TITLE
ねこ画像判定APIへのProxyを追加

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,7 +105,7 @@ module.exports = {
     'class-methods-use-this': 'off',
     'multiline-comment-style': 'off',
     'capitalized-comments': 'off',
-    'max-statements': ['error', 15],
+    'max-statements': ['error', 20],
     'max-lines-per-function': ['error', 60],
   },
   settings: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,6 +105,8 @@ module.exports = {
     'class-methods-use-this': 'off',
     'multiline-comment-style': 'off',
     'capitalized-comments': 'off',
+    'max-statements': ['error', 15],
+    'max-lines-per-function': ['error', 60],
   },
   settings: {
     'import/resolver': {

--- a/src/api/isAcceptableCatImage.ts
+++ b/src/api/isAcceptableCatImage.ts
@@ -1,0 +1,46 @@
+import { createFailureResult, createSuccessResult, Result } from '../result';
+
+import type { JwtAccessToken } from './issueAccessToken';
+
+type IsAcceptableCatImageRequest = {
+  accessToken: JwtAccessToken;
+  jsonRequestBody: string;
+};
+
+export type IsAcceptableCatImageNotAcceptableReason =
+  | 'not an allowed image extension'
+  | 'not moderation image'
+  | 'person face in the image'
+  | 'not cat image'
+  | 'an error has occurred';
+
+export type IsAcceptableCatImageResponse = {
+  isAcceptableCatImage: boolean;
+  notAcceptableReason: IsAcceptableCatImageNotAcceptableReason;
+};
+
+export const isAcceptableCatImage = async (
+  request: IsAcceptableCatImageRequest,
+): Promise<Result<IsAcceptableCatImageResponse, Error>> => {
+  const options: RequestInit = {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${request.accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: request.jsonRequestBody,
+  };
+
+  const response = await fetch(
+    `${IMAGE_RECOGNITION_API_URL}/cat-images/validation-results`,
+    options,
+  );
+
+  if (!response.ok) {
+    return createFailureResult(new Error('failed to isAcceptableCatImage'));
+  }
+
+  const responseBody = (await response.json()) as IsAcceptableCatImageResponse;
+
+  return createSuccessResult<IsAcceptableCatImageResponse>(responseBody);
+};

--- a/src/api/issueAccessToken.ts
+++ b/src/api/issueAccessToken.ts
@@ -13,7 +13,7 @@ type CognitoTokenResponseBody = {
   token_type: 'Bearer';
 };
 
-type JwtAccessToken = string;
+export type JwtAccessToken = string;
 
 export const issueAccessToken = async (
   request: IssueAccessTokenRequest,

--- a/src/api/issueAccessToken.ts
+++ b/src/api/issueAccessToken.ts
@@ -15,15 +15,17 @@ type CognitoTokenResponseBody = {
 
 export type JwtAccessToken = string;
 
-type IssueAccessTokenResponse = {
+type SuccessResponse = {
   jwtAccessToken: JwtAccessToken;
-  xRequestId?: string;
-  xLambdaRequestId?: string;
+};
+
+type FailureResponse = {
+  error: Error;
 };
 
 export const issueAccessToken = async (
   request: IssueAccessTokenRequest,
-): Promise<Result<IssueAccessTokenResponse, Error>> => {
+): Promise<Result<SuccessResponse, FailureResponse>> => {
   const authorization = btoa(
     `${request.cognitoClientId}:${request.cognitoClientSecret}`,
   );
@@ -39,7 +41,11 @@ export const issueAccessToken = async (
 
   const response = await fetch(request.endpoint, options);
   if (!response.ok) {
-    return createFailureResult(new Error('failed to issueAccessToken'));
+    const failureResponse = {
+      error: new Error('failed to issueAccessToken'),
+    };
+
+    return createFailureResult<FailureResponse>(failureResponse);
   }
 
   const responseBody = (await response.json()) as CognitoTokenResponseBody;

--- a/src/api/issueAccessToken.ts
+++ b/src/api/issueAccessToken.ts
@@ -1,3 +1,5 @@
+import { createFailureResult, createSuccessResult, Result } from '../result';
+
 type IssueAccessTokenRequest = {
   endpoint: string;
   cognitoClientId: string;
@@ -15,7 +17,7 @@ type JwtAccessToken = string;
 
 export const issueAccessToken = async (
   request: IssueAccessTokenRequest,
-): Promise<JwtAccessToken> => {
+): Promise<Result<JwtAccessToken, Error>> => {
   const authorization = btoa(
     `${request.cognitoClientId}:${request.cognitoClientSecret}`,
   );
@@ -30,8 +32,11 @@ export const issueAccessToken = async (
   };
 
   const response = await fetch(request.endpoint, options);
+  if (!response.ok) {
+    return createFailureResult(new Error('failed to issueAccessToken'));
+  }
 
   const responseBody = (await response.json()) as CognitoTokenResponseBody;
 
-  return responseBody.access_token;
+  return createSuccessResult(responseBody.access_token);
 };

--- a/src/api/issueAccessToken.ts
+++ b/src/api/issueAccessToken.ts
@@ -15,9 +15,15 @@ type CognitoTokenResponseBody = {
 
 export type JwtAccessToken = string;
 
+type IssueAccessTokenResponse = {
+  jwtAccessToken: JwtAccessToken;
+  xRequestId?: string;
+  xLambdaRequestId?: string;
+};
+
 export const issueAccessToken = async (
   request: IssueAccessTokenRequest,
-): Promise<Result<JwtAccessToken, Error>> => {
+): Promise<Result<IssueAccessTokenResponse, Error>> => {
   const authorization = btoa(
     `${request.cognitoClientId}:${request.cognitoClientSecret}`,
   );
@@ -38,5 +44,9 @@ export const issueAccessToken = async (
 
   const responseBody = (await response.json()) as CognitoTokenResponseBody;
 
-  return createSuccessResult(responseBody.access_token);
+  const issueAccessTokenResponse = {
+    jwtAccessToken: responseBody.access_token,
+  };
+
+  return createSuccessResult(issueAccessTokenResponse);
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,3 +3,4 @@
 declare const COGNITO_CLIENT_ID: string;
 declare const COGNITO_CLIENT_SECRET: string;
 declare const COGNITO_TOKEN_ENDPOINT: string;
+declare const IMAGE_RECOGNITION_API_URL: string;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -54,7 +54,7 @@ export const handleCatImageValidation = async (
   const jsonRequestBody = JSON.stringify(body);
 
   const isAcceptableCatImageRequest = {
-    accessToken: issueAccessTokenResult.value,
+    accessToken: issueAccessTokenResult.value.jwtAccessToken,
     jsonRequestBody,
   };
 
@@ -70,7 +70,8 @@ export const handleCatImageValidation = async (
     return createErrorResponse(errorBody, defaultErrorStatus);
   }
 
-  const responseBody = isAcceptableCatImageResult.value;
+  const responseBody =
+    isAcceptableCatImageResult.value.isAcceptableCatImageResponse;
 
   return createSuccessResponse(responseBody);
 };

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -8,13 +8,18 @@ const defaultSuccessStatus = 200;
 
 const defaultErrorStatus = 500;
 
+type ResponseHeader = {
+  'Content-Type': 'application/json';
+  'X-Request-Id'?: string;
+  'X-Lambda-Request-Id'?: string;
+};
+
 const createSuccessResponse = (
   body: unknown,
   statusCode = defaultSuccessStatus,
+  headers: ResponseHeader = { 'Content-Type': 'application/json' },
 ): Response => {
   const jsonBody = JSON.stringify(body);
-
-  const headers = { 'Content-Type': 'application/json' };
 
   return new Response(jsonBody, { headers, status: statusCode });
 };
@@ -73,7 +78,20 @@ export const handleCatImageValidation = async (
   const responseBody =
     isAcceptableCatImageResult.value.isAcceptableCatImageResponse;
 
-  return createSuccessResponse(responseBody);
+  const headers: ResponseHeader = {
+    'Content-Type': 'application/json',
+  };
+
+  if (isAcceptableCatImageResult.value.xRequestId) {
+    headers['X-Request-Id'] = isAcceptableCatImageResult.value.xRequestId;
+  }
+
+  if (isAcceptableCatImageResult.value.xLambdaRequestId) {
+    headers['X-Lambda-Request-Id'] =
+      isAcceptableCatImageResult.value.xLambdaRequestId;
+  }
+
+  return createSuccessResponse(responseBody, defaultSuccessStatus, headers);
 };
 
 export const handleNotFound = async (request: Request): Promise<Response> => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,0 +1,38 @@
+export const SuccessMarker = 'SuccessMarker';
+export const FailureMarker = 'FailureMarker';
+
+export type SuccessResult<T> = { value: T; _: typeof SuccessMarker };
+export type FailureResult<E> = { value: E; _: typeof FailureMarker };
+export type Result<T, E> = SuccessResult<T> | FailureResult<E>;
+
+export const createSuccessResult = <T>(value: T): SuccessResult<T> => ({
+  value,
+  // eslint-disable-next-line id-length
+  _: SuccessMarker,
+});
+
+export const createFailureResult = <E>(value: E): FailureResult<E> => ({
+  value,
+  // eslint-disable-next-line id-length
+  _: FailureMarker,
+});
+
+export const isSuccessResult = <T>(
+  result: Result<unknown, unknown>,
+): result is SuccessResult<T> => {
+  if ('_' in result) {
+    return result._ === SuccessMarker;
+  }
+
+  return false;
+};
+
+export const isFailureResult = <T>(
+  result: Result<unknown, unknown>,
+): result is FailureResult<T> => {
+  if ('_' in result) {
+    return result._ === FailureMarker;
+  }
+
+  return false;
+};


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/cloudflare-worker-api-proxy/issues/2

# 内容
ねこ画像判定API `/cat-images/validation-results` へのProxy機能を追加。

ResponseフォーマットやRequestのフォーマットを必要に応じて変更してある。