### PR TITLE
Zodを使ってAPIのレスポンスを検証するように変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "cloudflare-worker-api-proxy",
       "version": "0.0.0",
       "dependencies": {
-        "itty-router": "^2.6.6"
+        "itty-router": "^2.6.6",
+        "zod": "^3.19.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20221111.1",
@@ -9187,6 +9188,14 @@
         "mustache": "^4.2.0",
         "stack-trace": "0.0.10"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -15960,6 +15969,11 @@
         "mustache": "^4.2.0",
         "stack-trace": "0.0.10"
       }
+    },
+    "zod": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test": "jest --verbose"
   },
   "dependencies": {
-    "itty-router": "^2.6.6"
+    "itty-router": "^2.6.6",
+    "zod": "^3.19.1"
   }
 }

--- a/src/api/fetchLgtmImages.ts
+++ b/src/api/fetchLgtmImages.ts
@@ -70,6 +70,7 @@ export const fetchLgtmImagesInRandom = async (
 
   const responseBody = await response.json();
   if (isLgtmImages(responseBody)) {
+    // TODO idはnumber型で返すように変更する
     const successResponse: SuccessResponse = {
       lgtmImages: responseBody,
     };

--- a/src/api/fetchLgtmImages.ts
+++ b/src/api/fetchLgtmImages.ts
@@ -3,12 +3,12 @@ import { createFailureResult, createSuccessResult, Result } from '../result';
 import { validation } from '../validator';
 import { JwtAccessToken } from './issueAccessToken';
 
-type LgtmImage = { id: number; url: string };
+type LgtmImage = { id: string; url: string };
 
 type LgtmImages = LgtmImage[];
 
 const lgtmImageSchema = z.object({
-  id: z.number().min(1).max(Number.MAX_SAFE_INTEGER),
+  id: z.union([z.string().min(1), z.number().min(1)]),
   url: z.string().url(),
 });
 

--- a/src/api/issueAccessToken.ts
+++ b/src/api/issueAccessToken.ts
@@ -1,4 +1,6 @@
+import { z } from 'zod';
 import { createFailureResult, createSuccessResult, Result } from '../result';
+import { validation } from '../validator';
 
 type IssueAccessTokenRequest = {
   endpoint: string;
@@ -11,6 +13,18 @@ type CognitoTokenResponseBody = {
   // eslint-disable-next-line no-magic-numbers
   expires_in: 3600;
   token_type: 'Bearer';
+};
+
+const cognitoTokenResponseBodySchema = z.object({
+  access_token: z.string(),
+  expires_in: z.number().min(3600),
+  token_type: z.literal('Bearer'),
+});
+
+const isCognitoTokenResponseBody = (
+  value: unknown
+): value is CognitoTokenResponseBody => {
+  return validation(cognitoTokenResponseBodySchema, value).isValidate;
 };
 
 export type JwtAccessToken = string;
@@ -50,9 +64,18 @@ export const issueAccessToken = async (
 
   const responseBody = await response.json();
 
-  const issueAccessTokenResponse = {
-    jwtAccessToken: responseBody.access_token,
+  if (isCognitoTokenResponseBody(responseBody)) {
+    const issueAccessTokenResponse = {
+      jwtAccessToken: responseBody.access_token,
+    };
+
+    return createSuccessResult(issueAccessTokenResponse);
+  }
+
+  // TODO 後でバリデーション専用のエラーレスポンスを返すようにする
+  const failureResponse = {
+    error: new Error('response body is invalid'),
   };
 
-  return createSuccessResult(issueAccessTokenResponse);
+  return createFailureResult<FailureResponse>(failureResponse);
 };

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,0 +1,89 @@
+import { z, ZodError } from 'zod';
+
+type InvalidParam = {
+  name: string;
+  reason: string;
+};
+
+type InvalidParams = InvalidParam[];
+
+export type ValidationResult = {
+  isValidate: boolean;
+  invalidParams?: InvalidParams;
+};
+
+// eslint-disable-next-line max-statements
+const isInvalidParams = (value: unknown): value is InvalidParams => {
+  if (Array.isArray(value)) {
+    // eslint-disable-next-line no-magic-numbers
+    if (value.length === 0) {
+      return false;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const object = value[0];
+    if (Object.prototype.toString.call(object) !== '[object Object]') {
+      return false;
+    }
+
+    const invalidParam = object as InvalidParam;
+    if (!Object.prototype.hasOwnProperty.call(invalidParam, 'name')) {
+      return false;
+    }
+
+    return Object.prototype.hasOwnProperty.call(invalidParam, 'reason');
+  }
+
+  return false;
+};
+
+const isZodError = (error: unknown): error is ZodError => {
+  if (error instanceof ZodError) {
+    return true;
+  }
+
+  if (error instanceof Error) {
+    if (error.name === 'ZodError') {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export const createSchemaFromType =
+  <T>() =>
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+  <S extends z.ZodType<T, any, any>>(arg: S) =>
+    arg;
+
+type ValidationSchema = {
+  parse: (params: unknown) => unknown;
+};
+
+export const validation = (
+  schema: ValidationSchema,
+  params: unknown
+): ValidationResult => {
+  try {
+    schema.parse(params);
+
+    return { isValidate: true };
+  } catch (error) {
+    if (isZodError(error)) {
+      const invalidParams = error.errors.map((value) => ({
+        // eslint-disable-next-line no-magic-numbers
+        name: value.path[0],
+        reason: value.message,
+      }));
+
+      if (isInvalidParams(invalidParams)) {
+        return { isValidate: false, invalidParams };
+      }
+    }
+
+    throw error instanceof Error
+      ? new Error(error.message)
+      : new Error('failed to validation');
+  }
+};


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/cloudflare-worker-api-proxy/issues/21

# 内容
zodを利用してAPIのレスポンスをバリデーションするように変更。

バリデーションエラー発生時には専用のエラーを返すべきだが、それは別の課題で対応する。