### PR TITLE
Jestの設定を最新に更新

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,19 +1,12 @@
+const { defaults: tsjPreset } = require('ts-jest/presets');
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    ...tsjPreset.transform,
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  // https://github.com/zeit/next.js/issues/8663#issue-490553899
-  globals: {
-    // we must specify a custom tsconfig for tests because we need the typescript transform
-    // to transform jsx into js rather than leaving it jsx such as the next build requires. you
-    // can see this setting in tsconfig.jest.json -> "jsx": "react"
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.json',
-    },
-  },
 };


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/cloudflare-worker-api-proxy/issues/16

# 内容

Jestの設定を簡略化。

本来は以下のように `jest-environment-miniflare` を使うのが推奨されていそうですが、`msw` が正常動作しなくなったので引き続き `jest-environment-jsdom` を利用する事にした。

https://miniflare.dev/testing/jest