### PR TITLE
リクエスト時のバリデーションを追加

### DIFF
--- a/src/handlers/handleCatImageValidation.ts
+++ b/src/handlers/handleCatImageValidation.ts
@@ -1,6 +1,7 @@
 import { isAcceptableCatImage } from '../api/isAcceptableCatImage';
 import { issueAccessToken } from '../api/issueAccessToken';
 import { httpStatusCode } from '../httpStatusCode';
+import type { AcceptedTypesImageExtension } from '../lgtmImage';
 import { isFailureResult } from '../result';
 import {
   createErrorResponse,
@@ -17,7 +18,7 @@ type Dto = {
   };
   requestBody: {
     image: string;
-    imageExtension: string;
+    imageExtension: AcceptedTypesImageExtension;
   };
 };
 

--- a/src/handlers/handleCatImageValidation.ts
+++ b/src/handlers/handleCatImageValidation.ts
@@ -36,7 +36,10 @@ export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {
       status: httpStatusCode.internalServerError,
     } as const;
 
-    return createErrorResponse(problemDetails, httpStatusCode.internalServerError);
+    return createErrorResponse(
+      problemDetails,
+      httpStatusCode.internalServerError
+    );
   }
 
   const jsonRequestBody = JSON.stringify(dto.requestBody);
@@ -57,7 +60,10 @@ export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {
       status: httpStatusCode.internalServerError,
     } as const;
 
-    return createErrorResponse(problemDetails, httpStatusCode.internalServerError);
+    return createErrorResponse(
+      problemDetails,
+      httpStatusCode.internalServerError
+    );
   }
 
   const responseBody =

--- a/src/handlers/handleCatImageValidation.ts
+++ b/src/handlers/handleCatImageValidation.ts
@@ -30,13 +30,13 @@ export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {
 
   const issueAccessTokenResult = await issueAccessToken(issueTokenRequest);
   if (isFailureResult(issueAccessTokenResult)) {
-    const errorBody = {
+    const problemDetails = {
       title: 'failed to issue access token',
       type: 'InternalServerError',
       status: httpStatusCode.internalServerError,
     } as const;
 
-    return createErrorResponse(errorBody, httpStatusCode.internalServerError);
+    return createErrorResponse(problemDetails, httpStatusCode.internalServerError);
   }
 
   const jsonRequestBody = JSON.stringify(dto.requestBody);
@@ -51,13 +51,13 @@ export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {
     isAcceptableCatImageDto
   );
   if (isFailureResult(isAcceptableCatImageResult)) {
-    const errorBody = {
+    const problemDetails = {
       title: 'failed to is acceptable cat image',
       type: 'InternalServerError',
       status: httpStatusCode.internalServerError,
     } as const;
 
-    return createErrorResponse(errorBody, httpStatusCode.internalServerError);
+    return createErrorResponse(problemDetails, httpStatusCode.internalServerError);
   }
 
   const responseBody =

--- a/src/handlers/handleCatImageValidation.ts
+++ b/src/handlers/handleCatImageValidation.ts
@@ -1,8 +1,11 @@
+import { z } from 'zod';
 import { isAcceptableCatImage } from '../api/isAcceptableCatImage';
 import { issueAccessToken } from '../api/issueAccessToken';
 import { httpStatusCode } from '../httpStatusCode';
 import type { AcceptedTypesImageExtension } from '../lgtmImage';
+import { acceptedTypesImageExtensions } from '../lgtmImage';
 import { isFailureResult } from '../result';
+import { validation, ValidationResult } from '../validator';
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -20,6 +23,17 @@ type Dto = {
     image: string;
     imageExtension: AcceptedTypesImageExtension;
   };
+};
+
+export const validateHandleCatImageValidationRequestBody = (
+  value: unknown
+): ValidationResult => {
+  const schema = z.object({
+    image: z.string().min(1),
+    imageExtension: z.enum(acceptedTypesImageExtensions),
+  });
+
+  return validation(schema, value);
 };
 
 export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {

--- a/src/handlers/handleCatImageValidation.ts
+++ b/src/handlers/handleCatImageValidation.ts
@@ -31,9 +31,10 @@ export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {
   const issueAccessTokenResult = await issueAccessToken(issueTokenRequest);
   if (isFailureResult(issueAccessTokenResult)) {
     const errorBody = {
-      title: 'issue_access_token_failed',
+      title: 'failed to issue access token',
+      type: 'InternalServerError',
       status: httpStatusCode.internalServerError,
-    };
+    } as const;
 
     return createErrorResponse(errorBody, httpStatusCode.internalServerError);
   }
@@ -51,9 +52,10 @@ export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {
   );
   if (isFailureResult(isAcceptableCatImageResult)) {
     const errorBody = {
-      title: 'is_acceptable_cat_image_failed',
+      title: 'failed to is acceptable cat image',
+      type: 'InternalServerError',
       status: httpStatusCode.internalServerError,
-    };
+    } as const;
 
     return createErrorResponse(errorBody, httpStatusCode.internalServerError);
   }

--- a/src/handlers/handleFetchLgtmImagesInRandom.ts
+++ b/src/handlers/handleFetchLgtmImagesInRandom.ts
@@ -34,7 +34,10 @@ export const handleFetchLgtmImagesInRandom = async (
       status: httpStatusCode.internalServerError,
     } as const;
 
-    return createErrorResponse(problemDetails, httpStatusCode.internalServerError);
+    return createErrorResponse(
+      problemDetails,
+      httpStatusCode.internalServerError
+    );
   }
 
   const fetchLgtmImagesRequest = {
@@ -52,7 +55,10 @@ export const handleFetchLgtmImagesInRandom = async (
       status: httpStatusCode.internalServerError,
     } as const;
 
-    return createErrorResponse(problemDetails, httpStatusCode.internalServerError);
+    return createErrorResponse(
+      problemDetails,
+      httpStatusCode.internalServerError
+    );
   }
 
   const responseBody = fetchLgtmImagesResult.value.lgtmImages;

--- a/src/handlers/handleFetchLgtmImagesInRandom.ts
+++ b/src/handlers/handleFetchLgtmImagesInRandom.ts
@@ -28,13 +28,13 @@ export const handleFetchLgtmImagesInRandom = async (
 
   const issueAccessTokenResult = await issueAccessToken(issueTokenRequest);
   if (isFailureResult(issueAccessTokenResult)) {
-    const errorBody = {
+    const problemDetails = {
       title: 'failed to issue access token',
       type: 'InternalServerError',
       status: httpStatusCode.internalServerError,
     } as const;
 
-    return createErrorResponse(errorBody, httpStatusCode.internalServerError);
+    return createErrorResponse(problemDetails, httpStatusCode.internalServerError);
   }
 
   const fetchLgtmImagesRequest = {
@@ -46,13 +46,13 @@ export const handleFetchLgtmImagesInRandom = async (
     fetchLgtmImagesRequest
   );
   if (isFailureResult(fetchLgtmImagesResult)) {
-    const errorBody = {
+    const problemDetails = {
       title: 'failed to fetch lgtm images in random',
       type: 'InternalServerError',
       status: httpStatusCode.internalServerError,
     } as const;
 
-    return createErrorResponse(errorBody, httpStatusCode.internalServerError);
+    return createErrorResponse(problemDetails, httpStatusCode.internalServerError);
   }
 
   const responseBody = fetchLgtmImagesResult.value.lgtmImages;

--- a/src/handlers/handleFetchLgtmImagesInRandom.ts
+++ b/src/handlers/handleFetchLgtmImagesInRandom.ts
@@ -29,9 +29,10 @@ export const handleFetchLgtmImagesInRandom = async (
   const issueAccessTokenResult = await issueAccessToken(issueTokenRequest);
   if (isFailureResult(issueAccessTokenResult)) {
     const errorBody = {
-      title: 'issue_access_token_failed',
+      title: 'failed to issue access token',
+      type: 'InternalServerError',
       status: httpStatusCode.internalServerError,
-    };
+    } as const;
 
     return createErrorResponse(errorBody, httpStatusCode.internalServerError);
   }
@@ -46,9 +47,10 @@ export const handleFetchLgtmImagesInRandom = async (
   );
   if (isFailureResult(fetchLgtmImagesResult)) {
     const errorBody = {
-      title: 'fetch_lgtm_images_in_random_failed',
+      title: 'failed to fetch lgtm images in random',
+      type: 'InternalServerError',
       status: httpStatusCode.internalServerError,
-    };
+    } as const;
 
     return createErrorResponse(errorBody, httpStatusCode.internalServerError);
   }

--- a/src/handlers/handleNotFound.ts
+++ b/src/handlers/handleNotFound.ts
@@ -7,10 +7,11 @@ type Dto = {
 
 export const handleNotFound = (dto: Dto): Response => {
   const responseBody = {
-    title: `not_found`,
+    title: 'not found',
+    type: 'ResourceNotFound',
     detail: `${dto.url} is not found.`,
     status: httpStatusCode.notFound,
-  };
+  } as const;
 
   return createErrorResponse(responseBody, httpStatusCode.notFound);
 };

--- a/src/handlers/handleNotFound.ts
+++ b/src/handlers/handleNotFound.ts
@@ -6,12 +6,12 @@ type Dto = {
 };
 
 export const handleNotFound = (dto: Dto): Response => {
-  const responseBody = {
+  const problemDetails = {
     title: 'not found',
     type: 'ResourceNotFound',
     detail: `${dto.url} is not found.`,
     status: httpStatusCode.notFound,
   } as const;
 
-  return createErrorResponse(responseBody, httpStatusCode.notFound);
+  return createErrorResponse(problemDetails, httpStatusCode.notFound);
 };

--- a/src/handlers/handlerResponse.ts
+++ b/src/handlers/handlerResponse.ts
@@ -1,4 +1,5 @@
 import { HttpStatusCode, httpStatusCode } from '../httpStatusCode';
+import { InvalidParams } from '../validator';
 
 export type ResponseHeader = {
   'Content-Type': 'application/json';
@@ -18,9 +19,16 @@ export const createSuccessResponse = (
 
 export type ProblemDetails = {
   title: string;
-  type: 'ResourceNotFound' | 'ValidationError' | 'InternalServerError';
+  type: 'ResourceNotFound' | 'InternalServerError';
   status?: HttpStatusCode;
   detail?: string;
+};
+
+export type ValidationProblemDetails = ProblemDetails & {
+  title: 'unprocessable entity';
+  type: 'ValidationError';
+  status: typeof httpStatusCode.unprocessableEntity;
+  invalidParams: InvalidParams;
 };
 
 export const createErrorResponse = (

--- a/src/handlers/handlerResponse.ts
+++ b/src/handlers/handlerResponse.ts
@@ -18,9 +18,9 @@ export const createSuccessResponse = (
 
 export type ErrorBody = {
   title: string;
+  type: 'ResourceNotFound' | 'ValidationError' | 'InternalServerError';
+  status?: HttpStatusCode;
   detail?: string;
-  type?: string | 'about:blank';
-  status?: number;
 };
 
 export const createErrorResponse = (

--- a/src/handlers/handlerResponse.ts
+++ b/src/handlers/handlerResponse.ts
@@ -35,3 +35,19 @@ export const createErrorResponse = (
   problemDetails: ProblemDetails,
   statusCode: HttpStatusCode = httpStatusCode.internalServerError
 ): Response => createSuccessResponse(problemDetails, statusCode);
+
+export const createValidationErrorResponse = (
+  invalidParams: InvalidParams
+): Response => {
+  const validationProblemDetails = {
+    title: 'unprocessable entity',
+    type: 'ValidationError',
+    status: httpStatusCode.unprocessableEntity,
+    invalidParams,
+  } as const;
+
+  return createSuccessResponse(
+    validationProblemDetails,
+    httpStatusCode.unprocessableEntity
+  );
+};

--- a/src/handlers/handlerResponse.ts
+++ b/src/handlers/handlerResponse.ts
@@ -16,7 +16,7 @@ export const createSuccessResponse = (
   return new Response(jsonBody, { headers, status: statusCode });
 };
 
-export type ErrorBody = {
+export type ProblemDetails = {
   title: string;
   type: 'ResourceNotFound' | 'ValidationError' | 'InternalServerError';
   status?: HttpStatusCode;
@@ -24,6 +24,6 @@ export type ErrorBody = {
 };
 
 export const createErrorResponse = (
-  body: ErrorBody,
+  problemDetails: ProblemDetails,
   statusCode: HttpStatusCode = httpStatusCode.internalServerError
-): Response => createSuccessResponse(body, statusCode);
+): Response => createSuccessResponse(problemDetails, statusCode);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Bindings } from './bindings';
 import { handleCatImageValidation } from './handlers/handleCatImageValidation';
 import { handleFetchLgtmImagesInRandom } from './handlers/handleFetchLgtmImagesInRandom';
 import { handleNotFound } from './handlers/handleNotFound';
+import { AcceptedTypesImageExtension } from './lgtmImage';
 
 const app = new Hono<{ Bindings: Bindings }>();
 
@@ -29,7 +30,7 @@ app.post('/cat-images/validation-results', async (c) => {
   // TODO バリデーションを追加する
   const requestBody = await c.req.json<{
     image: string;
-    imageExtension: string;
+    imageExtension: AcceptedTypesImageExtension;
   }>();
 
   return await handleCatImageValidation({ env, requestBody });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 import { Hono } from 'hono';
 import { Bindings } from './bindings';
-import { handleCatImageValidation } from './handlers/handleCatImageValidation';
+import {
+  handleCatImageValidation,
+  validateHandleCatImageValidationRequestBody,
+} from './handlers/handleCatImageValidation';
 import { handleFetchLgtmImagesInRandom } from './handlers/handleFetchLgtmImagesInRandom';
 import { handleNotFound } from './handlers/handleNotFound';
+import { createValidationErrorResponse } from './handlers/handlerResponse';
 import { AcceptedTypesImageExtension } from './lgtmImage';
 
 const app = new Hono<{ Bindings: Bindings }>();
@@ -32,6 +36,12 @@ app.post('/cat-images/validation-results', async (c) => {
     image: string;
     imageExtension: AcceptedTypesImageExtension;
   }>();
+
+  const validationResult =
+    validateHandleCatImageValidationRequestBody(requestBody);
+  if (!validationResult.isValidate && validationResult.invalidParams != null) {
+    return createValidationErrorResponse(validationResult.invalidParams);
+  }
 
   return await handleCatImageValidation({ env, requestBody });
 });

--- a/src/lgtmImage.ts
+++ b/src/lgtmImage.ts
@@ -1,0 +1,4 @@
+export const acceptedTypesImageExtensions = ['.png', '.jpg', '.jpeg'] as const;
+
+export type AcceptedTypesImageExtension =
+  typeof acceptedTypesImageExtensions[number];

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -5,7 +5,7 @@ type InvalidParam = {
   reason: string;
 };
 
-type InvalidParams = InvalidParam[];
+export type InvalidParams = InvalidParam[];
 
 export type ValidationResult = {
   isValidate: boolean;


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/cloudflare-worker-api-proxy/issues/27

# 内容

以下のようにバリデーションエラー時に専用のレスポンスを返すようにした。

APIの返り値が意図した値でない場合のレスポンスは別PRで対応する。

```
{
  "title": "unprocessable entity",
  "type": "ValidationError",
  "status": 422,
  "invalidParams": [
    {
      "name": "image",
      "reason": "String must contain at least 1 character(s)"
    },
    {
      "name": "imageExtension",
      "reason": "Invalid enum value. Expected '.png' | '.jpg' | '.jpeg', received '.jpg__'"
    }
  ]
```