### PR TITLE
API レスポンスのバリデーション失敗時に専用のレスポンスを返すように変更

### DIFF
--- a/src/api/__tests__/fetchLgtmImagesInRandom.spec.ts
+++ b/src/api/__tests__/fetchLgtmImagesInRandom.spec.ts
@@ -8,6 +8,7 @@ import { setupServer } from 'msw/node';
 import mockInternalServerError from '../../mocks/api/error/mockInternalServerError';
 import fetchLgtmImagesMockBody from '../../mocks/api/fetchLgtmImagesMockBody';
 import mockFetchLgtmImages from '../../mocks/api/mockFetchLgtmImages';
+import { mockFetchLgtmImagesUnknownResponse } from '../../mocks/api/mockFetchLgtmImagesUnknownResponse';
 import { isSuccessResult } from '../../result';
 import { fetchLgtmImagesInRandom } from '../fetchLgtmImages';
 
@@ -58,6 +59,31 @@ describe('fetchLgtmImagesInRandom TestCases', () => {
 
     const expected = {
       error: new Error('failed to fetchLgtmImagesInRandom'),
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    expect(isSuccessResult(lgtmImagesResult)).toBeFalsy();
+    expect(lgtmImagesResult.value).toStrictEqual(expected);
+  });
+
+  it('should return a FailureResponse because the API Response type is different', async () => {
+    mockServer.use(
+      rest.get(`${apiUrl}/lgtm-images`, mockFetchLgtmImagesUnknownResponse)
+    );
+
+    const lgtmImagesResult = await fetchLgtmImagesInRandom({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+    });
+
+    const expected = {
+      invalidParams: [
+        { name: 'lgtmImages', reason: 'Invalid input' },
+        { name: 'lgtmImages', reason: 'Invalid url' },
+        { name: 'lgtmImages', reason: 'Invalid input' },
+        { name: 'lgtmImages', reason: 'Invalid url' },
+      ],
       xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
     };

--- a/src/api/fetchLgtmImages.ts
+++ b/src/api/fetchLgtmImages.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { createFailureResult, createSuccessResult, Result } from '../result';
 import { validation } from '../validator';
 import { JwtAccessToken } from './issueAccessToken';
+import { mightExtractRequestIds } from './mightExtractRequestIds';
 
 type LgtmImage = { id: string; url: string };
 
@@ -53,19 +54,12 @@ export const fetchLgtmImagesInRandom = async (
       error: new Error('failed to fetchLgtmImagesInRandom'),
     };
 
-    if (response.headers.get('x-request-id') != null) {
-      failureResponse.xRequestId = response.headers.get(
-        'x-request-id'
-      ) as string;
-    }
+    const requestIds = mightExtractRequestIds(response);
 
-    if (response.headers.get('x-lambda-request-id') != null) {
-      failureResponse.xLambdaRequestId = response.headers.get(
-        'x-lambda-request-id'
-      ) as string;
-    }
-
-    return createFailureResult<FailureResponse>(failureResponse);
+    return createFailureResult<FailureResponse>({
+      ...failureResponse,
+      ...requestIds,
+    });
   }
 
   const responseBody = await response.json();
@@ -75,19 +69,12 @@ export const fetchLgtmImagesInRandom = async (
       lgtmImages: responseBody,
     };
 
-    if (response.headers.get('x-request-id') != null) {
-      successResponse.xRequestId = response.headers.get(
-        'x-request-id'
-      ) as string;
-    }
+    const requestIds = mightExtractRequestIds(response);
 
-    if (response.headers.get('x-lambda-request-id') != null) {
-      successResponse.xLambdaRequestId = response.headers.get(
-        'x-lambda-request-id'
-      ) as string;
-    }
-
-    return createSuccessResult<SuccessResponse>(successResponse);
+    return createSuccessResult<SuccessResponse>({
+      ...successResponse,
+      ...requestIds,
+    });
   }
 
   // TODO 後でバリデーション専用のエラーレスポンスを返すようにする
@@ -95,15 +82,10 @@ export const fetchLgtmImagesInRandom = async (
     error: new Error('response body is invalid'),
   };
 
-  if (response.headers.get('x-request-id') != null) {
-    failureResponse.xRequestId = response.headers.get('x-request-id') as string;
-  }
+  const requestIds = mightExtractRequestIds(response);
 
-  if (response.headers.get('x-lambda-request-id') != null) {
-    failureResponse.xLambdaRequestId = response.headers.get(
-      'x-lambda-request-id'
-    ) as string;
-  }
-
-  return createFailureResult<FailureResponse>(failureResponse);
+  return createFailureResult<FailureResponse>({
+    ...failureResponse,
+    ...requestIds,
+  });
 };

--- a/src/api/fetchLgtmImages.ts
+++ b/src/api/fetchLgtmImages.ts
@@ -2,7 +2,11 @@ import { z } from 'zod';
 import { createFailureResult, createSuccessResult, Result } from '../result';
 import { validation } from '../validator';
 import { JwtAccessToken } from './issueAccessToken';
-import { mightExtractRequestIds } from './mightExtractRequestIds';
+import {
+  LambdaRequestId,
+  mightExtractRequestIds,
+  RequestId,
+} from './mightExtractRequestIds';
 
 type LgtmImage = { id: string; url: string };
 
@@ -28,14 +32,14 @@ type Dto = {
 
 type SuccessResponse = {
   lgtmImages: LgtmImages;
-  xRequestId?: string;
-  xLambdaRequestId?: string;
+  xRequestId?: RequestId;
+  xLambdaRequestId?: LambdaRequestId;
 };
 
 type FailureResponse = {
   error: Error;
-  xRequestId?: string;
-  xLambdaRequestId?: string;
+  xRequestId?: RequestId;
+  xLambdaRequestId?: LambdaRequestId;
 };
 
 export const fetchLgtmImagesInRandom = async (

--- a/src/api/isAcceptableCatImage.ts
+++ b/src/api/isAcceptableCatImage.ts
@@ -2,7 +2,11 @@ import { z } from 'zod';
 import { createFailureResult, createSuccessResult, Result } from '../result';
 import { validation } from '../validator';
 import type { JwtAccessToken } from './issueAccessToken';
-import { mightExtractRequestIds } from './mightExtractRequestIds';
+import {
+  LambdaRequestId,
+  mightExtractRequestIds,
+  RequestId,
+} from './mightExtractRequestIds';
 
 type Dto = {
   apiBaseUrl: string;
@@ -41,14 +45,14 @@ const isAcceptableCatImageResponse = (
 
 export type SuccessResponse = {
   isAcceptableCatImageResponse: IsAcceptableCatImageResponse;
-  xRequestId?: string;
-  xLambdaRequestId?: string;
+  xRequestId?: RequestId;
+  xLambdaRequestId?: LambdaRequestId;
 };
 
 export type FailureResponse = {
   error: Error;
-  xRequestId?: string;
-  xLambdaRequestId?: string;
+  xRequestId?: RequestId;
+  xLambdaRequestId?: LambdaRequestId;
 };
 
 export const isAcceptableCatImage = async (

--- a/src/api/isAcceptableCatImage.ts
+++ b/src/api/isAcceptableCatImage.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { createFailureResult, createSuccessResult, Result } from '../result';
 import { validation } from '../validator';
 import type { JwtAccessToken } from './issueAccessToken';
+import { mightExtractRequestIds } from './mightExtractRequestIds';
 
 type Dto = {
   apiBaseUrl: string;
@@ -72,19 +73,12 @@ export const isAcceptableCatImage = async (
       error: new Error('failed to isAcceptableCatImage'),
     };
 
-    if (response.headers.get('x-request-id') != null) {
-      failureResponse.xRequestId = response.headers.get(
-        'x-request-id'
-      ) as string;
-    }
+    const requestIds = mightExtractRequestIds(response);
 
-    if (response.headers.get('x-lambda-request-id') != null) {
-      failureResponse.xLambdaRequestId = response.headers.get(
-        'x-lambda-request-id'
-      ) as string;
-    }
-
-    return createFailureResult<FailureResponse>(failureResponse);
+    return createFailureResult<FailureResponse>({
+      ...failureResponse,
+      ...requestIds,
+    });
   }
 
   const responseBody = await response.json();
@@ -94,19 +88,12 @@ export const isAcceptableCatImage = async (
       isAcceptableCatImageResponse: responseBody,
     };
 
-    if (response.headers.get('x-request-id') != null) {
-      successResponse.xRequestId = response.headers.get(
-        'x-request-id'
-      ) as string;
-    }
+    const requestIds = mightExtractRequestIds(response);
 
-    if (response.headers.get('x-lambda-request-id') != null) {
-      successResponse.xLambdaRequestId = response.headers.get(
-        'x-lambda-request-id'
-      ) as string;
-    }
-
-    return createSuccessResult<SuccessResponse>(successResponse);
+    return createSuccessResult<SuccessResponse>({
+      ...successResponse,
+      ...requestIds,
+    });
   }
 
   // TODO 後でバリデーション専用のエラーレスポンスを返すようにする
@@ -114,15 +101,10 @@ export const isAcceptableCatImage = async (
     error: new Error('response body is invalid'),
   };
 
-  if (response.headers.get('x-request-id') != null) {
-    failureResponse.xRequestId = response.headers.get('x-request-id') as string;
-  }
+  const requestIds = mightExtractRequestIds(response);
 
-  if (response.headers.get('x-lambda-request-id') != null) {
-    failureResponse.xLambdaRequestId = response.headers.get(
-      'x-lambda-request-id'
-    ) as string;
-  }
-
-  return createFailureResult<FailureResponse>(failureResponse);
+  return createFailureResult<FailureResponse>({
+    ...failureResponse,
+    ...requestIds,
+  });
 };

--- a/src/api/mightExtractRequestIds.ts
+++ b/src/api/mightExtractRequestIds.ts
@@ -1,0 +1,26 @@
+import { Response } from '@cloudflare/workers-types/2021-11-03/index';
+
+export type RequestId = string;
+
+export type LambdaRequestId = string;
+
+type RequestIds = {
+  xRequestId?: RequestId;
+  xLambdaRequestId?: LambdaRequestId;
+};
+
+export const mightExtractRequestIds = (response: Response): RequestIds => {
+  const requestIds: RequestIds = {};
+
+  if (response.headers.get('x-request-id') != null) {
+    requestIds.xRequestId = response.headers.get('x-request-id') as string;
+  }
+
+  if (response.headers.get('x-lambda-request-id') != null) {
+    requestIds.xLambdaRequestId = response.headers.get(
+      'x-lambda-request-id'
+    ) as string;
+  }
+
+  return requestIds;
+};

--- a/src/api/validationErrorResponse.ts
+++ b/src/api/validationErrorResponse.ts
@@ -1,0 +1,44 @@
+import { Response } from '@cloudflare/workers-types/2021-11-03/index';
+import { z } from 'zod';
+import { InvalidParams, validation } from '../validator';
+import {
+  LambdaRequestId,
+  mightExtractRequestIds,
+  RequestId,
+} from './mightExtractRequestIds';
+
+export type ValidationErrorResponse = {
+  invalidParams: InvalidParams;
+  xRequestId?: RequestId;
+  xLambdaRequestId?: LambdaRequestId;
+};
+
+export const createValidationErrorResponse = (
+  invalidParams: InvalidParams,
+  response: Response
+): ValidationErrorResponse => {
+  const validationErrorResponse = {
+    invalidParams,
+  };
+
+  const requestIds = mightExtractRequestIds(response);
+
+  return { ...validationErrorResponse, ...requestIds };
+};
+
+const invalidParamSchema = z.object({
+  name: z.string().min(1),
+  reason: z.string().min(1),
+});
+
+const schema = z.object({
+  invalidParams: z.array(invalidParamSchema),
+  xRequestId: z.string().optional(),
+  xLambdaRequestId: z.string().optional(),
+});
+
+export const isValidationErrorResponse = (
+  value: unknown
+): value is ValidationErrorResponse => {
+  return validation(schema, value).isValidate;
+};

--- a/src/handlers/handleCatImageValidation.ts
+++ b/src/handlers/handleCatImageValidation.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { isAcceptableCatImage } from '../api/isAcceptableCatImage';
 import { issueAccessToken } from '../api/issueAccessToken';
+import { isValidationErrorResponse } from '../api/validationErrorResponse';
 import { httpStatusCode } from '../httpStatusCode';
 import type { AcceptedTypesImageExtension } from '../lgtmImage';
 import { acceptedTypesImageExtensions } from '../lgtmImage';
@@ -8,10 +9,10 @@ import { isFailureResult } from '../result';
 import { validation, ValidationResult } from '../validator';
 import {
   createErrorResponse,
-  createSuccessResponse, createValidationErrorResponse,
-  ResponseHeader, ValidationProblemDetails,
+  createSuccessResponse,
+  createValidationErrorResponse,
+  ResponseHeader,
 } from './handlerResponse';
-import {isValidationErrorResponse} from "../api/validationErrorResponse";
 
 type Dto = {
   env: {
@@ -84,8 +85,11 @@ export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {
   }
 
   if (isFailureResult(isAcceptableCatImageResult)) {
-    if (isValidationErrorResponse(isAcceptableCatImageResult)) {
-      return createValidationErrorResponse(isAcceptableCatImageResult.invalidParams, headers);
+    if (isValidationErrorResponse(isAcceptableCatImageResult.value)) {
+      return createValidationErrorResponse(
+        isAcceptableCatImageResult.value.invalidParams,
+        headers
+      );
     }
 
     const problemDetails = {
@@ -97,7 +101,7 @@ export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {
     return createErrorResponse(
       problemDetails,
       httpStatusCode.internalServerError,
-      headers,
+      headers
     );
   }
 

--- a/src/handlers/handleFetchLgtmImagesInRandom.ts
+++ b/src/handlers/handleFetchLgtmImagesInRandom.ts
@@ -1,13 +1,14 @@
 import { fetchLgtmImagesInRandom } from '../api/fetchLgtmImages';
 import { issueAccessToken } from '../api/issueAccessToken';
+import { isValidationErrorResponse } from '../api/validationErrorResponse';
 import { httpStatusCode } from '../httpStatusCode';
 import { isFailureResult } from '../result';
 import {
   createErrorResponse,
-  createSuccessResponse, createValidationErrorResponse,
+  createSuccessResponse,
+  createValidationErrorResponse,
   ResponseHeader,
 } from './handlerResponse';
-import {isValidationErrorResponse} from "../api/validationErrorResponse";
 
 type Dto = {
   env: {
@@ -64,8 +65,11 @@ export const handleFetchLgtmImagesInRandom = async (
   }
 
   if (isFailureResult(fetchLgtmImagesResult)) {
-    if (isValidationErrorResponse(fetchLgtmImagesResult)) {
-      return createValidationErrorResponse(fetchLgtmImagesResult.invalidParams, headers);
+    if (isValidationErrorResponse(fetchLgtmImagesResult.value)) {
+      return createValidationErrorResponse(
+        fetchLgtmImagesResult.value.invalidParams,
+        headers
+      );
     }
 
     const problemDetails = {

--- a/src/handlers/handlerResponse.ts
+++ b/src/handlers/handlerResponse.ts
@@ -33,11 +33,13 @@ export type ValidationProblemDetails = ProblemDetails & {
 
 export const createErrorResponse = (
   problemDetails: ProblemDetails,
-  statusCode: HttpStatusCode = httpStatusCode.internalServerError
-): Response => createSuccessResponse(problemDetails, statusCode);
+  statusCode: HttpStatusCode = httpStatusCode.internalServerError,
+  headers: ResponseHeader = { 'Content-Type': 'application/json' },
+): Response => createSuccessResponse(problemDetails, statusCode, headers);
 
 export const createValidationErrorResponse = (
-  invalidParams: InvalidParams
+  invalidParams: InvalidParams,
+  headers: ResponseHeader = { 'Content-Type': 'application/json' },
 ): Response => {
   const validationProblemDetails = {
     title: 'unprocessable entity',
@@ -48,6 +50,7 @@ export const createValidationErrorResponse = (
 
   return createSuccessResponse(
     validationProblemDetails,
-    httpStatusCode.unprocessableEntity
+    httpStatusCode.unprocessableEntity,
+    headers,
   );
 };

--- a/src/handlers/handlerResponse.ts
+++ b/src/handlers/handlerResponse.ts
@@ -34,12 +34,12 @@ export type ValidationProblemDetails = ProblemDetails & {
 export const createErrorResponse = (
   problemDetails: ProblemDetails,
   statusCode: HttpStatusCode = httpStatusCode.internalServerError,
-  headers: ResponseHeader = { 'Content-Type': 'application/json' },
+  headers: ResponseHeader = { 'Content-Type': 'application/json' }
 ): Response => createSuccessResponse(problemDetails, statusCode, headers);
 
 export const createValidationErrorResponse = (
   invalidParams: InvalidParams,
-  headers: ResponseHeader = { 'Content-Type': 'application/json' },
+  headers: ResponseHeader = { 'Content-Type': 'application/json' }
 ): Response => {
   const validationProblemDetails = {
     title: 'unprocessable entity',
@@ -51,6 +51,6 @@ export const createValidationErrorResponse = (
   return createSuccessResponse(
     validationProblemDetails,
     httpStatusCode.unprocessableEntity,
-    headers,
+    headers
   );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import { AcceptedTypesImageExtension } from './lgtmImage';
 const app = new Hono<{ Bindings: Bindings }>();
 
 app.get('/lgtm-images', async (c) => {
-  // TODO 環境変数のバリデーションを実施する
   return await handleFetchLgtmImagesInRandom({
     env: {
       cognitoTokenEndpoint: c.env.COGNITO_TOKEN_ENDPOINT,
@@ -31,7 +30,6 @@ app.post('/cat-images/validation-results', async (c) => {
     apiBaseUrl: c.env.IMAGE_RECOGNITION_API_URL,
   };
 
-  // TODO バリデーションを追加する
   const requestBody = await c.req.json<{
     image: string;
     imageExtension: AcceptedTypesImageExtension;

--- a/src/mocks/api/mockFetchLgtmImagesUnknownResponse.ts
+++ b/src/mocks/api/mockFetchLgtmImagesUnknownResponse.ts
@@ -1,0 +1,20 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockFetchLgtmImagesUnknownResponse: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      lgtmImages: [
+        { name: 'もこ', url: 'unknown' },
+        { name: 'プリン', url: 'unknown' },
+      ],
+    })
+  );


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/cloudflare-worker-api-proxy/issues/27

# 内容
- [x] リクエストIDを取り出す処理を共通化
- [x] API レスポンスのバリデーション失敗時に専用のレスポンスを返すように変更
- [x] APIレスポンスが異常だった場合のテストコードを実装

以下のようにResponseが返ってくる。

```
{
  "title": "unprocessable entity",
  "type": "ValidationError",
  "status": 422,
  "invalidParams": [
    {
      "name": "lgtmImages",
      "reason": "String must contain at most 1 character(s)"
    },
    {
      "name": "lgtmImages",
      "reason": "String must contain at most 1 character(s)"
    },
    {
      "name": "lgtmImages",
      "reason": "String must contain at most 1 character(s)"
    },
    {
      "name": "lgtmImages",
      "reason": "String must contain at most 1 character(s)"
    },
    {
      "name": "lgtmImages",
      "reason": "String must contain at most 1 character(s)"
    },
    {
      "name": "lgtmImages",
      "reason": "String must contain at most 1 character(s)"
    },
    {
      "name": "lgtmImages",
      "reason": "String must contain at most 1 character(s)"
    },
    {
      "name": "lgtmImages",
      "reason": "String must contain at most 1 character(s)"
    },
    {
      "name": "lgtmImages",
      "reason": "String must contain at most 1 character(s)"
    }
  ]
}
```