### PR TITLE
アクセストークンをKVにCacheするように変更

### DIFF
--- a/src/api/cacheClient.ts
+++ b/src/api/cacheClient.ts
@@ -1,0 +1,1 @@
+export type CacheClient = KVNamespace;

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -4,4 +4,5 @@ export type Bindings = {
   COGNITO_TOKEN_ENDPOINT: string;
   IMAGE_RECOGNITION_API_URL: string;
   LGTMEOW_API_URL: string;
+  COGNITO_TOKEN: KVNamespace;
 };

--- a/src/handlers/handleCatImageValidation.ts
+++ b/src/handlers/handleCatImageValidation.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { CacheClient } from '../api/cacheClient';
 import { isAcceptableCatImage } from '../api/isAcceptableCatImage';
 import { issueAccessToken } from '../api/issueAccessToken';
 import { isValidationErrorResponse } from '../api/validationErrorResponse';
@@ -20,6 +21,7 @@ type Dto = {
     cognitoClientId: string;
     cognitoClientSecret: string;
     apiBaseUrl: string;
+    cacheClient: CacheClient;
   };
   requestBody: {
     image: string;
@@ -43,6 +45,7 @@ export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {
     endpoint: dto.env.cognitoTokenEndpoint,
     cognitoClientId: dto.env.cognitoClientId,
     cognitoClientSecret: dto.env.cognitoClientSecret,
+    cacheClient: dto.env.cacheClient,
   };
 
   const issueAccessTokenResult = await issueAccessToken(issueTokenRequest);

--- a/src/handlers/handleFetchLgtmImagesInRandom.ts
+++ b/src/handlers/handleFetchLgtmImagesInRandom.ts
@@ -1,3 +1,4 @@
+import type { CacheClient } from '../api/cacheClient';
 import { fetchLgtmImagesInRandom } from '../api/fetchLgtmImages';
 import { issueAccessToken } from '../api/issueAccessToken';
 import { isValidationErrorResponse } from '../api/validationErrorResponse';
@@ -16,6 +17,7 @@ type Dto = {
     cognitoClientId: string;
     cognitoClientSecret: string;
     apiBaseUrl: string;
+    cacheClient: CacheClient;
   };
 };
 
@@ -26,6 +28,7 @@ export const handleFetchLgtmImagesInRandom = async (
     endpoint: dto.env.cognitoTokenEndpoint,
     cognitoClientId: dto.env.cognitoClientId,
     cognitoClientSecret: dto.env.cognitoClientSecret,
+    cacheClient: dto.env.cacheClient,
   };
 
   const issueAccessTokenResult = await issueAccessToken(issueTokenRequest);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ app.get('/lgtm-images', async (c) => {
       cognitoClientId: c.env.COGNITO_CLIENT_ID,
       cognitoClientSecret: c.env.COGNITO_CLIENT_SECRET,
       apiBaseUrl: c.env.LGTMEOW_API_URL,
+      cacheClient: c.env.COGNITO_TOKEN,
     },
   });
 });
@@ -28,6 +29,7 @@ app.post('/cat-images/validation-results', async (c) => {
     cognitoClientId: c.env.COGNITO_CLIENT_ID,
     cognitoClientSecret: c.env.COGNITO_CLIENT_SECRET,
     apiBaseUrl: c.env.IMAGE_RECOGNITION_API_URL,
+    cacheClient: c.env.COGNITO_TOKEN,
   };
 
   const requestBody = await c.req.json<{

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,6 @@
 name = "cloudflare-worker-api-proxy"
 main = "src/index.ts"
 compatibility_date = "2022-05-21"
+kv_namespaces = [
+  { binding = "COGNITO_TOKEN", id = "ae13471aae89415ea11b969959910c2e", preview_id = "6dd9ad13fee34440aa96284e79693c40" }
+]


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/cloudflare-worker-api-proxy/issues/3

# 内容
[Cloudflare Workers KV store](https://developers.cloudflare.com/workers/runtime-apis/kv/) でアクセストークンをcacheするように改修。

詳細はインラインコメントに記載。