### PR TITLE
ステージング、本番の2種類の環境で動作させるように設定を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   },
   "private": true,
   "scripts": {
-    "start": "wrangler dev",
-    "publish": "wrangler publish",
+    "start": "wrangler dev --env staging",
+    "deploy:production": "wrangler publish",
+    "deploy:staging": "wrangler publish --env staging",
     "lint:prettier": "prettier --check .",
     "fix:prettier": "npm run lint:prettier -- --write",
     "lint:eslint": "eslint .",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,3 +4,9 @@ compatibility_date = "2022-05-21"
 kv_namespaces = [
   { binding = "COGNITO_TOKEN", id = "ae13471aae89415ea11b969959910c2e", preview_id = "6dd9ad13fee34440aa96284e79693c40" }
 ]
+
+[env.staging]
+name = "cloudflare-worker-api-proxy-staging"
+kv_namespaces = [
+  { binding = "COGNITO_TOKEN", id = "ae13471aae89415ea11b969959910c2e", preview_id = "6dd9ad13fee34440aa96284e79693c40" }
+]


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/cloudflare-worker-api-proxy/issues/18

# 内容

ステージング環境で動作する設定を追加。

ローカルで動作させる時はステージングのAPIを参照するように変更。

以下のようにステージング用の環境変数を追加しました。

```
wrangler secret put --env staging COGNITO_CLIENT_ID

wrangler secret put --env staging COGNITO_CLIENT_SECRET

wrangler secret put --env staging COGNITO_TOKEN_ENDPOINT

wrangler secret put --env staging LGTMEOW_API_URL

wrangler secret put --env staging IMAGE_RECOGNITION_API_URL
```

元々追加されていた `secret` には本番用の値を追加するようにした。

これによって本番環境のAPIにリクエストを送信可能になった。