### PR TITLE
SentryのDSNを環境変数から取得するように変更 + 軽微なリファクタリング

### DIFF
--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -6,4 +6,5 @@ export type Bindings = {
   IMAGE_RECOGNITION_API_URL: string;
   LGTMEOW_API_URL: string;
   COGNITO_TOKEN: KVNamespace;
+  SENTRY_DSN: `https://${string}@${string}.ingest.sentry.io/${string}`;
 };

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -2,9 +2,9 @@ export type Bindings = {
   APP_ENV: 'staging' | 'production';
   COGNITO_CLIENT_ID: string;
   COGNITO_CLIENT_SECRET: string;
-  COGNITO_TOKEN_ENDPOINT: string;
-  IMAGE_RECOGNITION_API_URL: string;
-  LGTMEOW_API_URL: string;
+  COGNITO_TOKEN_ENDPOINT: `https://${string}`;
+  IMAGE_RECOGNITION_API_URL: `https://${string}`;
+  LGTMEOW_API_URL: `https://${string}`;
   COGNITO_TOKEN: KVNamespace;
   SENTRY_DSN: `https://${string}@${string}.ingest.sentry.io/${string}`;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,10 +74,10 @@ app.onError((error, c) => {
     status: httpStatusCode.internalServerError,
   } as const;
 
-  const $sentry = getSentry(c);
-  $sentry.setTag('requestIds', error.message);
-  $sentry.setTag('environment', c.env.APP_ENV);
-  $sentry.captureException(error);
+  const sentryHandler = getSentry(c);
+  sentryHandler.setTag('requestIds', error.message);
+  sentryHandler.setTag('environment', c.env.APP_ENV);
+  sentryHandler.captureException(error);
 
   return c.json(problemDetails, httpStatusCode.internalServerError);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,11 @@ import { AcceptedTypesImageExtension } from './lgtmImage';
 
 const app = new Hono<{ Bindings: Bindings }>();
 
-app.use(
-  '*',
-  sentry({
-    dsn: 'https://42809d9efa8849f88f0136ced7917950@o1223117.ingest.sentry.io/4504248714330112',
-  })
-);
+app.use('*', async (c, next) => {
+  const handler = sentry({ dsn: c.env.SENTRY_DSN });
+
+  await handler(c, next);
+});
 
 app.use('*', async (c, next) => {
   const handler =


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/cloudflare-worker-api-proxy/issues/48

# やった事
表題の通り、SentryのDSNを環境変数から取得するように変更。

また以下の軽微なリファクタリングも実施。

- $から始める変数名は特殊なので変数名を変更
- envで設定する型定義をもう少し厳密な型に変更